### PR TITLE
docs: add use-styled to component variant libraries list

### DIFF
--- a/content/docs/guides/custom-components.mdx
+++ b/content/docs/guides/custom-components.mdx
@@ -55,6 +55,7 @@ Creating your own variants can quickly become complex. We recommend using a clas
 - [tw-classed](https://tw-classed.vercel.app)
 - [clsx](https://www.npmjs.com/package/clsx)
 - [classnames](https://www.npmjs.com/package/classnames)
+- [use-styled](https://usestyled.com/)
 
 ## Merging with inline styles
 


### PR DESCRIPTION
Re-submitting this PR here, as requested, due to the site moving to the new repository
Original PR: [here](https://github.com/nativewind/nativewind/pull/1477)

---

Hi team,

This PR adds [use-styled](https://usestyled.com/) to the list of recommended libraries for managing component variants in the "How to write custom components" guide.

This addition can provide users with another valuable option for their NativeWind projects.

Thanks!