### PR TITLE
blog with docs layout for easy navigation

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -11,7 +11,7 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/page';
 import { ArrowLeft } from 'lucide-react';
-import FooterSection from '../../FooterSection';
+import FooterSection from '../../(home)/FooterSection';
 
 export default async function Page(props: {
   params: Promise<{ slug: string }>;
@@ -24,17 +24,26 @@ export default async function Page(props: {
 
   return (
     <>
-      <div className="w-full mx-auto rounded-xl border pt-16 max-w-fd-container box-content flex flex-col items-start relative">
+      {/* <div className="w-full mx-auto rounded-xl border pt-16 max-w-fd-container box-content flex flex-col items-start relative">
 
         <div className="left-1/2 -translate-x-1/2 bottom-0 w-full max-w-fd-container absolute overflow-clip h-full pointer-events-none">
           <div className="bg-grid-dots rounded-full w-[50rem] h-[50rem] absolute bottom-0 right-0 translate-x-1/2 translate-y-1/2 [mask-image:radial-gradient(red,transparent_80%)] opacity-50"/>
           <div className="absolute bottom-0 right-0 translate-x-1/2 h-[64rem] w-screen bg-grid-lines-y-lg translate-y-1/2 max-md:hidden [--mask:radial-gradient(circle_at_center,red,transparent)] [mask-image:var(--mask)] [webkit-mask-image:var(--mask)] -skew-20" />
           <div className="absolute bottom-0 right-0 translate-x-1/2 translate-y-1/2 w-[64rem] h-[64rem] rounded-full bg-fd-primary/5 max-md:hidden [--mask:radial-gradient(circle_at_center,red,transparent_69%)] [mask-image:var(--mask)] [webkit-mask-image:var(--mask)]" />
         </div>
+      </div> */}
 
-        <div className="flex flex-col gap-2 px-4">
+      <DocsPage toc={page.data.toc} full={page.data.full}
+        tableOfContent={{
+          style: 'clerk',
+          single: false,
+        }}
+      >
+        
+        <div className="flex flex-col gap-2">
           <p className="text-xs text-fd-muted-foreground/50 font-mono">{new Date(page.data.date).toDateString()}</p>
-          <h2 className="text-2xl truncate group-hover:text-fd-primary duration-300">{page.data.title}</h2>
+          <DocsTitle>{page.data.title}</DocsTitle>
+          {/* <h2 className="text-2xl truncate group-hover:text-fd-primary duration-300">{page.data.title}</h2> */}
           {page.data.tags && (
             <div className="flex gap-2 -ml-2">
               {page.data.tags.map((tag: string) => (
@@ -44,9 +53,10 @@ export default async function Page(props: {
               ))}
             </div>
           )}
-          <p className="mb-4 line-clamp-3 text-fd-muted-foreground">{page.data.description}</p>
+          <DocsDescription className="mb-0">{page.data.description}</DocsDescription>
+          {/* <p className="mb-4 line-clamp-3 text-fd-muted-foreground">{page.data.description}</p> */}
           {page.data.authors && (
-            <div className="flex gap-6 mt-2">
+            <div className="flex gap-6 mt-4 mb-8">
               {page.data.authors.map((author: {
                 name: string,
                 title: string,
@@ -68,7 +78,7 @@ export default async function Page(props: {
             </div>
           )}
         </div>
-        <div className="flex gap-4 w-full items-end p-4">
+        {/* <div className="flex gap-4 w-full items-end p-4">
           <Link href="/blog"
             className="relative group flex items-center gap-2 opacity-90 duration-300 cut-corners py-2 px-4 rounded-tr-md rounded-bl-md bg-black text-black sm:text-white dark:hover:text-black dark:bg-white/5 font-bold hover:opacity-100"
           >
@@ -78,16 +88,7 @@ export default async function Page(props: {
             <ArrowLeft className="w-5 h-5 ease-[cubic-bezier(0.175,0.885,0.32,1.275)] duration-300 group-hover:-translate-x-0.5 translate-x-0.5" />
           </Link>
           <InlineTOC className="flex-1 w-full prose [&>button]:!py-1.5" items={page.data.toc} />
-        </div>
-      </div>
-      {/* <DocsPage toc={page.data.toc} full={page.data.full}
-        tableOfContent={{
-          style: 'clerk',
-          single: false,
-        }}
-      >
-        <DocsTitle>{page.data.title}</DocsTitle>
-        <DocsDescription>{page.data.description}</DocsDescription>
+        </div> */}
         <DocsBody>
           <MDX components={{
             ...defaultMdxComponents as any,
@@ -97,17 +98,17 @@ export default async function Page(props: {
             Callout,
           }} />
         </DocsBody>
-      </DocsPage> */}
-      <article className="w-full mx-auto flex flex-col max-md:px-4 max-lg:px-8 py-8 max-w-fd-container">
+      </DocsPage>
+      {/* <article className="w-full mx-auto flex flex-col max-md:px-4 max-lg:px-8 py-8 max-w-fd-container">
         <div className="prose min-w-0">
           <MDX components={defaultMdxComponents} />
         </div>
-      </article>
+      </article> */}
 
-      <div className="relative">
+      {/* <div className="relative">
         <div className="absolute max-w-fd-container lg:w-[calc(100%-1rem)] box-content lg:border-x border-dashed top-0 left-1/2 -translate-x-1/2 h-full pointer-events-none" />
         <FooterSection />
-      </div>
+      </div> */}
     </>
   );
 }

--- a/app/blog/layout.tsx
+++ b/app/blog/layout.tsx
@@ -1,0 +1,105 @@
+import { DocsLayout } from '@/components/notebook';
+import type { ReactNode } from 'react';
+import { blog } from '@/lib/source';
+import { Wordmark } from '../assets';
+import { RootToggle } from '@/components/layout/root-toggle';
+import Link from 'next/link';
+import { BookOpen, BookText, Heart, LayoutTemplate, UserRound } from 'lucide-react';
+
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <DocsLayout
+      themeSwitch={{
+        mode: 'light-dark',
+      }}
+      tree={blog.pageTree}
+      // links: [],
+      githubUrl='https://github.com/nativewind/nativewind'
+      // NOTE: for /layouts/notebook option https://fumadocs.vercel.app/docs/ui/layouts/docs#notebook
+      nav={{
+        // transparentMode: 'top',
+        title: (
+          <Wordmark className="h-6 group-hover:text-fd-primary duration-300" />
+        ),
+        afterTitle: (
+          <RootToggle
+            options={[
+          
+              {
+                title: 'v4',
+                url: '/docs',
+              },
+              {
+                title: 'v2',
+                url: 'https://v2.nativewind.dev/',
+              },
+            ]}
+          />
+        ),
+        mode: 'top',
+      }}
+      // TODO: remove, probably won't be used...
+      // tabMode: 'navbar',
+      sidebar={{
+        collapsible: true,
+        // NOTE: for 2+ root:true metas https://fumadocs.vercel.app/docs/ui/layouts/docs#sidebar-tabs
+        // TODO: remove, probably won't be used
+        tabs: {
+          transform(option, node) {
+            const meta = blog.getNodeMeta(node);
+            if (!meta) return option;
+
+            const color = `var(--${meta.file.dirname}-color, var(--color-fd-foreground))`;
+
+            return {
+              ...option,
+              icon: (
+                <div
+                  className="rounded-md p-1 shadow-lg ring-2 [&_svg]:size-5"
+                  style={
+                    {
+                      color,
+                      border: `1px solid color-mix(in oklab, ${color} 50%, transparent)`,
+                      '--tw-ring-color': `color-mix(in oklab, ${color} 20%, transparent)`,
+                    } as object
+                  }
+                >
+                  {node.icon}
+                </div>
+              ),
+            };
+          },
+        },
+        // NOTE: stays pinned when scrolling the sidebar
+        banner: (
+          <div className="flex flex-col gap-4 pt-2 lg:hidden">
+            {/* <div className="flex flex-col pt-2 gap-2 w-full rounded-xl bg-gradient-to-b from-fd-primary/20 to-cyan-300/50 backdrop-blur p-4">
+              <h1 className="text-xl font-bold mt-1">Nativewind v5 <i className="opacity-50">beta</i></h1>
+              <p className="text-sm text-fd-foreground/60">
+                Check out the new features and improvements in the latest version of Nativewind.
+              </p>
+              <Link
+                href="/docs/overview"
+                className="relative flex bg-white w-fit mt-1 text-black flex-row items-center gap-2 rounded-md p-2 text-start [overflow-wrap:anywhere] md:py-1.5 [&_svg]:size-4 [&_svg]:shrink-0 transition-colors hover:bg-fd-accent/50 hover:text-fd-accent-foreground/80 hover:transition-none"
+                style={{ paddingInlineStart: 'calc(var(--spacing) * 2)' }}
+              >
+                <BookOpen />
+                Read more
+              </Link>
+            </div> */}
+            <Link href="/blog" className="text-sm flex flex-row items-center gap-2 rounded-md p-2 text-start [overflow-wrap:anywhere] md:py-1.5 [&_svg]:size-4 [&_svg]:shrink-0 bg-fd-primary/10 text-fd-primary" style={{ paddingInlineStart: 'calc(var(--spacing) * 2)' }} >
+              <BookOpen />
+              Blog
+            </Link>
+          </div>
+        ),
+      }}
+    >
+      <div className="absolute top-0 xl:right-1/2 right-0 translate-x-1/2 -z-10 -translate-y-1/2 w-[64rem] h-[64rem] rounded-full bg-fd-primary/10 max-md:hidden [--mask:radial-gradient(circle_at_center,red,transparent_69%)] [mask-image:var(--mask)] [webkit-mask-image:var(--mask)] pointer-events-none" />
+      <div className="fixed top-0 xl:right-1/2 right-0 translate-x-1/2 -z-10 -translate-y-1/2 w-[64rem] h-[64rem] rounded-full bg-fd-primary/5 max-md:hidden [--mask:radial-gradient(circle_at_center,red,transparent_69%)] [mask-image:var(--mask)] [webkit-mask-image:var(--mask)] pointer-events-none" />
+      <div className="absolute top-0 xl:right-1/2 right-0 translate-x-1/2 -z-10 h-[64rem] w-[64rem] bg-grid-lines-xl dark:opacity-80 -translate-y-1/2 max-md:hidden [--mask:radial-gradient(circle_at_center_top,red,transparent)] [mask-image:var(--mask)] [webkit-mask-image:var(--mask)] -skew-20 pointer-events-none"/>
+      {children}
+    </DocsLayout>
+  );
+}

--- a/components/notebook.client.tsx
+++ b/components/notebook.client.tsx
@@ -5,7 +5,7 @@ import { useSidebar } from 'fumadocs-ui/provider';
 import { useNav } from 'fumadocs-ui/provider';
 import { SidebarTrigger } from 'fumadocs-core/sidebar';
 import { buttonVariants } from './ui/button';
-import { Menu, X } from 'lucide-react';
+import { BookOpen, BookText, Menu, X } from 'lucide-react';
 import Link from 'fumadocs-core/link';
 import { usePathname } from 'next/navigation';
 import { isActive } from '../lib/is-active';
@@ -124,4 +124,15 @@ export function SidebarLayoutTab({
       {item.title}
     </Link>
   );
+}
+
+export function DynamicLabel() {
+  const currentPath = usePathname();
+  const isDocs = currentPath.startsWith('/docs');
+  return (
+    <Link href={isDocs ? '/docs' : '/blog'} className={`lg:flex absolute ${isDocs ? 'left-4' : 'left-[calc((100vw-var(--fd-layout-width))/2_+_1rem)]'} hidden top-3 text-sm flex-row items-center gap-2 rounded-md p-2 text-start [overflow-wrap:anywhere] md:py-1.5 [&_svg]:size-4 [&_svg]:shrink-0 bg-fd-primary/10 text-fd-primary`} style={{ paddingInlineStart: 'calc(var(--spacing) * 2)' }} >
+      {isDocs ? <BookOpen /> : <BookText />}
+      {isDocs ? 'Docs' : 'Blog'}
+    </Link>
+  )
 }

--- a/components/notebook.tsx
+++ b/components/notebook.tsx
@@ -39,6 +39,7 @@ import {
 } from './docs/shared';
 import type { PageTree } from 'fumadocs-core/server';
 import {
+  DynamicLabel,
   LayoutTab,
   LayoutTabs,
   Navbar,
@@ -274,11 +275,7 @@ function DocsNavbar({
               <SidebarIcon />
             </SidebarCollapseTrigger>
           ) : null} */}
-          {/* TODO: use currentPathname (blog|docs) */}
-          <Link href="/docs" className="lg:flex absolute left-4 hidden top-3 text-sm flex-row items-center gap-2 rounded-md p-2 text-start [overflow-wrap:anywhere] md:py-1.5 [&_svg]:size-4 [&_svg]:shrink-0 bg-fd-primary/10 text-fd-primary" style={{ paddingInlineStart: 'calc(var(--spacing) * 2)' }} >
-            <BookOpen />
-            Docs
-          </Link>
+          <DynamicLabel />
           <Link
             href={nav.url ?? '/'}
             className={cn(

--- a/content/blog/meta.json
+++ b/content/blog/meta.json
@@ -1,0 +1,10 @@
+{
+  "pages": [
+    "[BookOpen][Docs](/docs/)",
+    "[LayoutTemplate][Showcase](/#showcase)",
+
+    "---Posts---",
+    "announcement-nativewind-v4-1",
+    "announcement-nativewind-v4"
+  ]
+}

--- a/lib/source.ts
+++ b/lib/source.ts
@@ -17,10 +17,16 @@ export const source = loader({
 });
 
 // blog
-import { blog as blogPosts } from '@/.source';
+import { blog as blogPosts, blogMeta } from '@/.source';
 import { createMDXSource } from 'fumadocs-mdx';
 
 export const blog = loader({
   baseUrl: '/blog',
-  source: createMDXSource(blogPosts),
+  source: createMDXSource(blogPosts, blogMeta),
+  // NOTE: adds icon support to meta.json
+  icon(icon) {
+    if (!icon) return undefined;
+    if (icon in icons) return createElement(icons[icon as keyof typeof icons]);
+    return undefined;
+  },
 });

--- a/source.config.ts
+++ b/source.config.ts
@@ -5,6 +5,11 @@ export const docs = defineDocs({
   dir: 'content/docs',
 });
 
+export const blogMeta = defineCollections({
+  type: 'meta',
+  dir: 'content/blog',
+});
+
 export const blog = defineCollections({
   type: 'doc',
   dir: 'content/blog',


### PR DESCRIPTION
before
<img width="1728" alt="Screenshot 2025-05-27 at 4 16 03 PM" src="https://github.com/user-attachments/assets/cd2c607a-5609-4550-8bc2-f9c44f00f912" />

after
<img width="1728" alt="Screenshot 2025-05-27 at 4 15 35 PM" src="https://github.com/user-attachments/assets/e368f2e2-02fa-42f1-a85f-12116fd1976e" />

the docs
<img width="1728" alt="Screenshot 2025-05-27 at 4 16 27 PM" src="https://github.com/user-attachments/assets/eccbe2c4-9938-484c-b5da-9c055f5251f1" />
