### PR TITLE
Fix typo: Add comma's to themes object

### DIFF
--- a/content/docs/guides/themes.mdx
+++ b/content/docs/guides/themes.mdx
@@ -65,21 +65,21 @@ import { vars, useColorScheme } from 'nativewind'
 const themes = {
   brand: {
     'light': vars({
-      '--color-primary': 'black'
+      '--color-primary': 'black',
       '--color-secondary': 'white'
     }),
     'dark': vars({
-      '--color-primary': 'white'
+      '--color-primary': 'white',
       '--color-secondary': 'dark'
     })
   },
   christmas: {
     'light': vars({
-      '--color-primary': 'red'
+      '--color-primary': 'red',
       '--color-secondary': 'green'
     }),
     'dark': vars({
-      '--color-primary': 'green'
+      '--color-primary': 'green',
       '--color-secondary': 'red'
     })
   }


### PR DESCRIPTION
# What this pullrequest does: 

- Comma's were missing in the themes object in the dynamic themes example (content/docs/guides/themes.mdx), 
- Added them so the copy pasting the example works as intended
