### PR TITLE
Resources update + bugfix

### DIFF
--- a/app/(home)/resources/community-posts.ts
+++ b/app/(home)/resources/community-posts.ts
@@ -51,6 +51,19 @@ export const posts = [
     }
   },
   {
+    title: "NativeTemplates",
+    url: "https://www.native-templates.com/",
+    image: "https://github.com/thomino/expo-playground/blob/main/assets/img/readme/readme.jpg?raw=true",
+    description: "React Native apps with working flows, theming, and logic — built using Expo, NativeWind, and TypeScript. Ready for iOS and Android",
+    author: {
+      name: 'Thomino',
+      username: 'thomino',
+      avatar: 'https://avatars.githubusercontent.com/u/4378611?v=4',
+      github: "https://github.com/thomino",
+      twitter: "https://x.com/thomino",
+    }
+  },
+  {
     title: "expo-auto-resizing-input",
     url: "https://github.com/rs-4/expo-auto-resizing-input",
     image: ExpoAutoResizingInput,

--- a/content/docs/tailwind/_legend.mdx
+++ b/content/docs/tailwind/_legend.mdx
@@ -2,7 +2,7 @@
 title: _legend.mdx
 ---
 
-<details className="bg-fd-primary/20 border-fd-primary border rounded-xl p-4 text-fd-foreground cursor-pointer w-[500px]">
+<details className="bg-fd-primary/20 border-fd-primary border rounded-xl p-4 text-fd-foreground cursor-pointer max-w-full w-[500px]">
   <summary>Legend</summary>
 
 ### Class


### PR DESCRIPTION
- fix legends width overflowing on moby
<img width="408" alt="Screenshot 2025-06-20 at 10 00 27 AM" src="https://github.com/user-attachments/assets/fce9f0fe-9f96-489c-97f3-2cd21f6e036d" />

- update /resources contents with https://www.native-templates.com/