### PR TITLE
fix(docs): correct 'Other Bundlers' link in Additional Setup Guides

### DIFF
--- a/content/docs/getting-started/installation/_additional-guides.mdx
+++ b/content/docs/getting-started/installation/_additional-guides.mdx
@@ -5,4 +5,4 @@ title: Additional Setup Guides
 ## Additional Setup Guides
 
 - [Editor Setup](./editor-setup) - Learn how to set up your editor to use Nativewind
-- [Other Bundlers](./other-bundlers) - Learn how to use Nativewind with other bundlers 
+- [Other Bundlers](/docs/guides/other-bundlers) - Learn how to use Nativewind with other bundlers 

--- a/content/docs/getting-started/installation/nextjs.mdx
+++ b/content/docs/getting-started/installation/nextjs.mdx
@@ -121,4 +121,4 @@ module.exports = {
 ## Additional Setup Guides
 
 - [Using with Monorepos](./using-with-monorepos) - Learn how to set up Nativewind in monorepo environments like NX
-- [Other Bundlers](./other-bundlers) - Learn how to use Nativewind with other bundlers
+- [Other Bundlers](/docs/guides/other-bundlers) - Learn how to use Nativewind with other bundlers


### PR DESCRIPTION
## What
This PR fixes the "Other Bundlers" link in the Additional Setup Guides section.  
The link previously pointed to `./other-bundlers`, but the correct path is `/docs/guides/other-bundlers`.

## Why
The previous link led to a non-existent or incorrect page.  
This update ensures users are directed to the correct documentation.

## Reference
- [Official contributing guide](https://github.com/nativewind/nativewind/blob/main/contributing.md)
- [Correct docs page](https://www.nativewind.dev/docs/guides/other-bundlers)