### PR TITLE
Fix incorrect pnpm dev install flag in installation docs

### DIFF
--- a/content/docs/getting-started/installation/_npm.mdx
+++ b/content/docs/getting-started/installation/_npm.mdx
@@ -40,7 +40,7 @@ import { CodeBlock, Pre } from 'fumadocs-ui/components/codeblock';
         {[
           props.deps?.length ? `pnpm install ${props.deps.join(" ")}` : undefined,
           props.devDeps?.length
-            ? `pnpm install --dev ${props.devDeps.join(" ")}`
+            ? `pnpm install -D ${props.devDeps.join(" ")}`
             : undefined,
         ]
           .filter(Boolean)


### PR DESCRIPTION
This PR updates the installation instructions for pnpm in the documentation.

Previously, the command used `pnpm install --dev`, which is not a valid flag in pnpm. 
The correct syntax for installing devDependencies with pnpm is `pnpm install -D`.

This change ensures consistency with pnpm's CLI and prevents confusion for developers following the setup guide.
