### PR TITLE
Rename pixelRatio functions to pixelScale

### DIFF
--- a/content/docs/customization/theme.md
+++ b/content/docs/customization/theme.md
@@ -71,35 +71,35 @@ module.exports = {
 };
 ```
 
-### pixelRatio()
+### pixelScale()
 
 Equivalent of [`PixelRatio.get()`](https://reactnative.dev/docs/pixelratio#get). If a number is provided it returns `PixelRatio.get() * <value>`, otherwise it returns the PixelRatio value.
 
 ```ts title=tailwind.config.js
-const { pixelRatio } = require("nativewind/theme");
+const { pixelScale } = require("nativewind/theme");
 
 module.exports = {
   theme: {
     extend: {
       borderWidth: {
-        number: pixelRatio(2),
+        number: pixelScale(2),
       },
     },
   },
 };
 ```
 
-### pixelRatioSelect()
+### pixelScaleSelect()
 
 A helper function to use [`PixelRatio.get()`](https://reactnative.dev/docs/pixelratio#get) in a conditional statement, similar to `Platform.select`.
 
 ```ts title=tailwind.config.js
-const { pixelRatio, hairlineWidth } = require("nativewind/theme");
+const { pixelScale, hairlineWidth } = require("nativewind/theme");
 
 module.exports = {
   theme: {
     extend: {
-      borderWidth: pixelRatioSelect({
+      borderWidth: pixelScaleSelect({
         2: 1,
         default: hairlineWidth(),
       }),


### PR DESCRIPTION
Change to the `theme`'s customization documentation where the `pixelRatio` and `pixelRatioSelect` functions are not exported by the implementation (see #45 for more details), but `pixelScale` and `pixelScaleSelect` are.

This PR is based on the assumptions
 - that `pixelScale` and `pixelRatio` have the same behaviour, side-effects, and outputs, then this could be a simple case of documentation-implementation reconciliation.
 - that the complexity of renaming these functions across multiple code sections and packages is far greater and shadows the effort required compared to a simple documentation change.

---

Closes #45 