### PR TITLE
docs: fix pnpm dev install command

### DIFF
--- a/content/v5/getting-started/installation/_npm.mdx
+++ b/content/v5/getting-started/installation/_npm.mdx
@@ -71,7 +71,7 @@ import { CodeBlock, Pre } from "fumadocs-ui/components/codeblock";
             ? `pnpm install ${props.deps.join(" ")}`
             : undefined,
           props.devDeps?.length
-            ? `pnpm install --dev ${props.devDeps.join(" ")}`
+            ? `pnpm install --save-dev ${props.devDeps.join(" ")}`
             : undefined,
         ]
           .filter(Boolean)


### PR DESCRIPTION
This PR corrects the pnpm installation command in the documentation.

Previously the docs suggested using `pnpm install --dev`, which is invalid.

With pnpm, the correct syntax is:

`pnpm add --save-dev <package>`

This aligns the docs with pnpm’s CLI conventions and ensures users can
successfully install devDependencies.