### PR TITLE
Add 'react-native-worklets' to dependencies

### DIFF
--- a/content/docs/getting-started/installation/_install.mdx
+++ b/content/docs/getting-started/installation/_install.mdx
@@ -12,6 +12,7 @@ You will need to install `nativewind` and its peer dependencies `tailwindcss`, `
     "nativewind",
     "react-native-reanimated",
     "react-native-safe-area-context",
+    "react-native-worklets"
   ]}
   devDeps={[
     "tailwindcss@^3.4.17",


### PR DESCRIPTION
Root cause: I was setting up nativewind with `react-native-macos`, and the styles weren't taking effect. Realised the latest version of the `react-native-reanimated` also requires `react-native-worklets` now

Issue: https://github.com/software-mansion/react-native-reanimated/issues/7185

Reference: https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/getting-started/#dependencies