### PR TITLE
Fix: clarify sidebar version switch button label from 'v4' or 'v5' to 'View {versionName} docs'

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -64,7 +64,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                   style={{ paddingInlineStart: "calc(var(--spacing) * 2)" }}
                 >
                   <BookOpen />
-                  v5
+                  View v5 docs
                 </Link>
               </div>
             </div>

--- a/app/v5/layout.tsx
+++ b/app/v5/layout.tsx
@@ -64,7 +64,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                   style={{ paddingInlineStart: "calc(var(--spacing) * 2)" }}
                 >
                   <BookOpen />
-                  v4
+                  View v4 docs
                 </Link>
               </div>
             </div>


### PR DESCRIPTION
## Issue
When browsing the v5 docs, the top-left button shows "v4", which is ambiguous and may suggest the current version instead of an action. The same can be seen on the v4 docs sidebar.
<img width="493" height="307" alt="image" src="https://github.com/user-attachments/assets/bc54cc64-e017-400d-9684-907f3ab02afa" />


## Fix
Updated the label to "View v4 docs" for v5 docs and vice versa to make the intent clearer.
<img width="383" height="253" alt="Screenshot From 2026-04-02 20-14-11" src="https://github.com/user-attachments/assets/06bd8d28-4b90-4bb0-873a-b57a052c7cc5" />



## Impact
Improves UX and reduces confusion for users navigating between versions.