### PR TITLE
fix: deprecated nativeStyleToProp to nativestyleMapping

### DIFF
--- a/content/v5/api/styled.mdx
+++ b/content/v5/api/styled.mdx
@@ -28,9 +28,9 @@ import { Svg, Circle } from "react-native-svg";
 const StyledSvg = styled(Svg, {
   className: {
     target: "style",
-    nativeStyleToProp: {
-      height: true,
-      width: true,
+    nativeStyleMapping: {
+      height: "height",
+      width: "width",
     },
   },
 });
@@ -38,10 +38,10 @@ const StyledSvg = styled(Svg, {
 const StyledCircle = styled(Circle, {
   className: {
     target: "style",
-    nativeStyleToProp: {
-      fill: true,
-      stroke: true,
-      strokeWidth: true,
+    nativeStyleMapping: {
+      fill: "fill",
+      stroke: "stroke",
+      strokeWidth: "strokeWidth",
     },
   },
 });


### PR DESCRIPTION
I was trying to get `SymbolView` from `expo-symbols` to work with styled.
The v5/api/styled show example of using `nativeStyleToProp`, when v5 uses `nativeStyleMapping` instead.

```tsx
// from doc instruction
const StyledSymbolView = styled(SymbolView, {
    className: {
        target: "style",
        nativeStyleToProp: {
            tintColor: "style.color",
            weight: "style.fontWeight",
            size: "style.fontSize",
        },
    },
});

// what actually works
const StyledSymbolView = styled(SymbolView, {
    className: {
        target: "style",
        nativeStyleMapping: {
            color: "tintColor",
            fontWeight: "weight",
            fontSize: "size",
        },
    },
});
```

Currently, the only valid type for nativeStyleMapping (if declared) is `Record<string,string>`, like `[styleSheetKey]: componentPropsKey`,
This is a minimal change in documentation (just changing the code example), but I think it would be nice if this page could be structured like the `api/withNativeWind` page, with options describing target, nativeStyleMapping, etc in the future.