### PR TITLE
docs: fix typos in color opacity differences documentation

### DIFF
--- a/content/docs/core-concepts/differences.md
+++ b/content/docs/core-concepts/differences.md
@@ -41,6 +41,6 @@ React Native's `<Text />` renders with a `fontSize: 14`, while the web's default
 
 ## Color Opacity
 
-For performance reasons, Nativewind renders with the `corePlugins`: `textOpacity`,`borderOpacity`, `divideOpacity` and `backgroundOpacity` disabled. Theses plugin allows colors to dynamically changed via CSS variables. Instead, the opacity is set as a static value in the `color` property.
+For performance reasons, Nativewind renders with the `corePlugins`: `textOpacity`,`borderOpacity`, `divideOpacity` and `backgroundOpacity` disabled. These plugins allow colors to be dynamically changed via CSS variables. Instead in Nativewind, the opacity is set as a static value in the `color` property.
 
 If you require this functionality, you can enable the disabled plugins in your `tailwind.config.js` file.


### PR DESCRIPTION
There was typos and an opportunity to make the explanation clearer in: https://www.nativewind.dev/docs/core-concepts/differences 

This PR covers those