### PR TITLE
Add Ronin Software credit to the footer

### DIFF
--- a/app/(home)/FooterSection.tsx
+++ b/app/(home)/FooterSection.tsx
@@ -38,7 +38,8 @@ export default function FooterSection() {
           <div className="flex items-center w-full justify-between py-4 border-t border-fd-foreground/10 mix-blend-plus-darker dark:mix-blend-plus-lighter mt-10 max-lg:px-8">
             <div className="text-xs">
               <div className="inline-block -scale-x-100 mr-1">©</div>
-              Copyright {new Date().getFullYear()}
+              Copyright {new Date().getFullYear()}. Built by{" "}
+              <a href="https://ronindevs.com/?utm_source=nativewind&utm_medium=site" target="_blank" rel="noopener noreferrer" className="hover:decoration-fd-primary hover:underline-offset-2 hover:text-fd-foreground decoration-transparent underline duration-300">Ronin Software</a>.
             </div>
             <ThemeToggle mode="light-dark-system" />
           </div>


### PR DESCRIPTION
Adds a "Built by Ronin Software" credit to the footer's copyright line, linking to ronindevs.com tagged `utm_source=nativewind&utm_medium=site`. Matches the footer's existing link styling. Part of wiring Nativewind into the Ronin booking funnel (the site already has Vercel Analytics).