### PR TITLE
docs: pin react-native-css to @latest in v5 install commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Context
+
+Read this file for project context:
+
+- @DEVELOPMENT.md — architecture, content authoring, commands, pitfalls

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,120 @@
+# Nativewind Documentation Site Development Guide
+
+## Project Overview
+
+The Nativewind documentation site serves both v4 (stable) and v5 (preview) docs side-by-side. Built with Next.js 15 and Fumadocs.
+
+- **V4 docs** at `/docs/` — sourced from `content/docs/`
+- **V5 docs** at `/v5/` — sourced from `content/v5/`
+- **Blog** at `/blog/` — sourced from `content/blog/`
+
+## Tech Stack
+
+- **Framework:** Next.js 15 (App Router)
+- **Docs engine:** Fumadocs (fumadocs-core, fumadocs-mdx, fumadocs-ui)
+- **Styling:** Tailwind CSS 4
+- **Package manager:** pnpm (npm and yarn are not used)
+- **Deployment:** Vercel
+
+## Commands
+
+```bash
+pnpm install             # Install dependencies
+pnpm dev                 # Start dev server
+pnpm build               # Production build
+pnpm start               # Start production server
+```
+
+## Content Authoring
+
+### Doc pages
+
+MDX files with YAML frontmatter:
+
+```mdx
+---
+title: "Page Title"
+description: "Optional description"
+---
+
+Content here...
+```
+
+### Sidebar navigation
+
+Controlled by `meta.json` files in each content directory — not by filesystem auto-discovery:
+
+```json
+[
+  "index",
+  "---Getting Started---",
+  "getting-started/installation/index",
+  "[BookText] Core Concepts"
+]
+```
+
+- `"---Section Name---"` — section headers
+- `"[IconName]"` — Lucide icon prefix
+- `"...tailwind/layout"` — spread operator to include all files in a directory
+
+### Shared MDX components
+
+- `<Tabs>` / `<Tab>` — tabbed content
+- `<Callout>` — tips/warnings
+- `<Steps>` — step-by-step guides
+- Partial imports: `import Install from './_install.mdx'`
+
+## Key Directories
+
+```
+app/
+├── (home)/              # Landing page, blog, resources, hire-us
+├── docs/[[...slug]]/    # V4 doc pages
+├── v5/[[...slug]]/      # V5 doc pages
+├── llms.mdx/            # LLM-friendly markdown endpoints
+├── llms.txt/            # Concatenated LLM text (v4)
+├── v5/llms.txt/         # Concatenated LLM text (v5)
+└── api/                 # Search, OG image generation
+
+components/
+├── notebook.tsx         # Custom Fumadocs DocsLayout wrapper
+├── layout/              # Sidebar, version switcher, theme toggle
+├── ui/                  # Radix UI wrappers
+└── home/                # Homepage components
+
+content/
+├── docs/                # V4 documentation (209 files)
+├── v5/                  # V5 documentation (200 files)
+└── blog/                # Blog posts
+
+lib/
+├── source.ts            # Fumadocs loaders (source for v4, source5 for v5)
+└── get-llm-text.ts      # Strips frontmatter, formats docs for LLM endpoints
+```
+
+## Key Config Files
+
+- **`source.config.ts`** — Fumadocs MDX config; defines `docs` (v4) and `docs5` (v5) collections
+- **`next.config.mjs`** — MDX integration, URL rewrites for LLM endpoints, SVG support
+- **`vercel.json`** — deployment config, redirects (`/discord`, `/issue`, `/repro`)
+
+## LLM Endpoints
+
+The site has built-in endpoints for serving docs as plain text for LLM consumption:
+
+| Endpoint | Description |
+|----------|-------------|
+| `/llms.txt` | Concatenated v4 docs as plain text |
+| `/v5/llms.txt` | Concatenated v5 docs as plain text |
+| `/llms-full.txt` | Full v4 doc dump |
+| `/v5/llms-full.txt` | Full v5 doc dump |
+| `/llms.mdx/docs/[path]` | Individual v4 doc as markdown |
+| `/llms.mdx/v5/[path]` | Individual v5 doc as markdown |
+
+## Common Pitfalls
+
+- **pnpm only** — not npm or yarn
+- **Sidebar is meta.json-driven** — adding a new MDX file doesn't automatically add it to navigation; update the relevant `meta.json`
+- **`.source/` is generated** — run `fumadocs-mdx` (happens on postinstall) to regenerate after content structure changes
+- **V4 and V5 have separate Fumadocs loaders** — `source` for v4, `source5` for v5 in `lib/source.ts`; don't mix them
+- **Last modified timestamps come from git** — configured in `source.config.ts`

--- a/NATIVEWIND_INSTALLATION_GUIDE.md
+++ b/NATIVEWIND_INSTALLATION_GUIDE.md
@@ -38,27 +38,27 @@ Install `nativewind` and its peer dependencies: `tailwindcss`, `react-native-css
 
 **Expo CLI (Recommended for Expo projects):**
 ```bash
-npx expo install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+npx expo install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 ```
 
 **npm:**
 ```bash
-npm install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+npm install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 ```
 
 **yarn:**
 ```bash
-yarn add nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+yarn add nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 ```
 
 **pnpm:**
 ```bash
-pnpm install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+pnpm install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 ```
 
 **bun:**
 ```bash
-bun install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+bun install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 ```
 
 ### Step 2: Install Tailwind CSS and PostCSS

--- a/components/copy-installation-button.tsx
+++ b/components/copy-installation-button.tsx
@@ -28,27 +28,27 @@ Install \`nativewind\` and its peer dependencies: \`tailwindcss\`, \`react-nativ
 
 **Expo CLI (Recommended for Expo projects):**
 \`\`\`bash
-npx expo install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+npx expo install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 \`\`\`
 
 **npm:**
 \`\`\`bash
-npm install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+npm install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 \`\`\`
 
 **yarn:**
 \`\`\`bash
-yarn add nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+yarn add nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 \`\`\`
 
 **pnpm:**
 \`\`\`bash
-pnpm install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+pnpm install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 \`\`\`
 
 **bun:**
 \`\`\`bash
-bun install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+bun install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 \`\`\`
 
 ### Step 2: Install Tailwind CSS and PostCSS

--- a/components/copy-migration-button.tsx
+++ b/components/copy-migration-button.tsx
@@ -48,7 +48,7 @@ Install the new versions of required packages:
 
 \`\`\`bash
 # Using Expo CLI (recommended)
-npx expo install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+npx expo install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 
 # Install Tailwind CSS v4 and PostCSS as dev dependencies
 npx expo install --dev tailwindcss @tailwindcss/postcss postcss

--- a/content/blog/v5-migration-guide.mdx
+++ b/content/blog/v5-migration-guide.mdx
@@ -47,7 +47,7 @@ Install the new versions of required packages:
 
 ```bash
 # Using Expo CLI (recommended)
-npx expo install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+npx expo install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 
 # Install Tailwind CSS v4 and PostCSS as dev dependencies
 npx expo install --dev tailwindcss @tailwindcss/postcss postcss

--- a/content/v5/getting-started/installation/_install.mdx
+++ b/content/v5/getting-started/installation/_install.mdx
@@ -10,7 +10,7 @@ You will need to install `nativewind` and its peer dependencies `tailwindcss`, `
   framework={props.framework}
   deps={[
     "nativewind@preview",
-    "react-native-css",
+    "react-native-css@latest",
     "react-native-reanimated",
     "react-native-safe-area-context",
   ]}

--- a/content/v5/guides/migrate-from-v4.mdx
+++ b/content/v5/guides/migrate-from-v4.mdx
@@ -19,7 +19,7 @@ Install the new versions of required packages:
 
 ```bash
 # Using Expo CLI (recommended)
-npx expo install nativewind@preview react-native-css react-native-reanimated react-native-safe-area-context
+npx expo install nativewind@preview react-native-css@latest react-native-reanimated react-native-safe-area-context
 
 # Install Tailwind CSS v4 and PostCSS as dev dependencies
 npx expo install --dev tailwindcss @tailwindcss/postcss postcss


### PR DESCRIPTION
## Problem

Old `react-native-css` nightlies from the SDK 54 preview era are still installable from npm, and their peer dependencies are exact pinned (for example `expo@54.0.0-preview.6`, `react-native@0.81.0`). A project that ends up with one of those, usually via a stale lockfile or an old template, fails to resolve on Expo SDK 55 and newer with an `ERESOLVE` error. This was reported by a user hitting it on a fresh Expo SDK 56 project.

The documented v5 install command listed `react-native-css` with no version, which leaves room for that drift.

## Change

Pin `react-native-css` to `@latest` everywhere the v5 install command appears:

* `content/v5/getting-started/installation/_install.mdx` (drives the rendered install page and every package manager tab)
* `content/v5/guides/migrate-from-v4.mdx` (also feeds `v5/llms-full.txt`)
* `content/blog/v5-migration-guide.mdx`
* `NATIVEWIND_INSTALLATION_GUIDE.md`
* `components/copy-installation-button.tsx`
* `components/copy-migration-button.tsx`

`@latest` resolves to `react-native-css@3.0.7` today, which is fully Expo SDK 56 compatible (peers `react-native >=0.81`, `react >=19`, `@expo/metro-config >=54`).

## Related

The specific broken nightly `react-native-css@0.0.0-nightly.5ce6396` has been deprecated on npm.
