### PR TITLE
docs: fix theme helper names

### DIFF
--- a/content/docs/customization/theme.md
+++ b/content/docs/customization/theme.md
@@ -71,35 +71,35 @@ module.exports = {
 };
 ```
 
-### pixelRatio()
+### pixelScale()
 
 Equivalent of [`PixelRatio.get()`](https://reactnative.dev/docs/pixelratio#get). If a number is provided it returns `PixelRatio.get() * <value>`, otherwise it returns the PixelRatio value.
 
 ```ts title=tailwind.config.js
-const { pixelRatio } = require("nativewind/theme");
+const { pixelScale } = require("nativewind/theme");
 
 module.exports = {
   theme: {
     extend: {
       borderWidth: {
-        number: pixelRatio(2),
+        number: pixelScale(2),
       },
     },
   },
 };
 ```
 
-### pixelRatioSelect()
+### pixelScaleSelect()
 
 A helper function to use [`PixelRatio.get()`](https://reactnative.dev/docs/pixelratio#get) in a conditional statement, similar to `Platform.select`.
 
 ```ts title=tailwind.config.js
-const { pixelRatio, hairlineWidth } = require("nativewind/theme");
+const { pixelScaleSelect, hairlineWidth } = require("nativewind/theme");
 
 module.exports = {
   theme: {
     extend: {
-      borderWidth: pixelRatioSelect({
+      borderWidth: pixelScaleSelect({
         2: 1,
         default: hairlineWidth(),
       }),


### PR DESCRIPTION
## Summary

- Renames the v4 theme docs helpers from `pixelRatio` / `pixelRatioSelect` to `pixelScale` / `pixelScaleSelect` to match the exported API.
- Updates the related `nativewind/theme` imports and examples.

Fixes #58.

## Test plan

- `git diff --check`
- `pnpm install --frozen-lockfile && pnpm validate` (fails on existing unrelated inaccessible URLs; `content/docs/customization/theme.md` validates successfully)